### PR TITLE
Docs: Rename "Ultrassonic.h" to "Ultrassonic.cpp"

### DIFF
--- a/src/Ultrasonic.cpp
+++ b/src/Ultrasonic.cpp
@@ -1,5 +1,5 @@
 /*
- * Ultrasonic.h
+ * Ultrasonic.cpp
  * 
  * Library for HC-SR04 Ultrasonic Ranging Module in a minimalist way
  *


### PR DESCRIPTION
Rename "Ultrassonic.h" to "Ultrassonic.cpp" in the header of the Ultrassonic.cpp file.

Resolves: #27