### PR TITLE
Feature: add timeout without pulseIn

### DIFF
--- a/src/Ultrasonic.cpp
+++ b/src/Ultrasonic.cpp
@@ -13,6 +13,8 @@
  * by Eliot Lim    (github: @eliotlim)
  * modified 10 Jun 2018
  * by Erick Simões (github: @ErickSimoes | twitter: @AloErickSimoes)
+ * modified 14 Jun 2018
+ * by Otacilio Maia (github: @OtacilioN | linkedIn: in/otacilio)
  *
  * Released into the MIT License.
  */
@@ -49,7 +51,7 @@ unsigned int Ultrasonic::timing() {
 
   while(!digitalRead(echo)); // wait for the echo pin HIGH
   previousMicros = micros();
-  while(digitalRead(echo)); // wait for the echo pin LOW
+  while(digitalRead(echo)  && (micros() - previousMicros) <= timeout); // wait for the echo pin LOW
 
   return micros() - previousMicros; // duration
 }

--- a/src/Ultrasonic.cpp
+++ b/src/Ultrasonic.cpp
@@ -48,8 +48,9 @@ unsigned int Ultrasonic::timing() {
 
   if (threePins)
     pinMode(trig, INPUT);
-
-  while(!digitalRead(echo)); // wait for the echo pin HIGH
+  
+  previousMicros = micros();
+  while(!digitalRead(echo) && (micros() - previousMicros) <= timeout); // wait for the echo pin HIGH
   previousMicros = micros();
   while(digitalRead(echo)  && (micros() - previousMicros) <= timeout); // wait for the echo pin LOW
 


### PR DESCRIPTION
### Summary

Add timeout feature without using pulseIn timeout function, completing the removal of the pulseIn function, it fixes #45 

### Description of the Change

add an and verification in the while that waits for the pulse get back to also verify if the current time is lowest or equal to the timeout

### Benefits

Now is fully compatible with pulseIn but also compatible with platforms that pulseIn does not works
