### PR TITLE
Creation of update function by a maximum distance.

### DIFF
--- a/src/Ultrasonic.h
+++ b/src/Ultrasonic.h
@@ -33,6 +33,7 @@ class Ultrasonic {
     unsigned int read(uint8_t und = CM);
     unsigned int distanceRead(uint8_t und = CM) __attribute__ ((deprecated ("This method is deprecated, use read() instead.")));
     void setTimeout(unsigned long timeOut) {timeout = timeOut;}
+    void setMaxDistance(unsigned long dist) {timeout = dist*CM*2;}
 
   private:
     uint8_t trig;


### PR DESCRIPTION
### Summary

Updating the timeout value by the maximum distance you want to read.

### Description of the Change

The timeout value is given by the maximum distance value that you want to read.

### Benefits

Now you can make the maximum distance setting read directly using the desired distance value, not the time.

### Possible Drawbacks

I can't imagine any

### Verification Process

I did not try it, sorry :/

### Applicable Issues

When you keep a close distance and you do not have to "waste time" trying to measure great distances and the ease of converting distance to time.
