### PR TITLE
docs: link to multiple Readme languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/releases/latest)
 ![Arduino Lint](https://github.com/ErickSimoes/Ultrasonic/workflows/Arduino%20Lint/badge.svg)
 
+🇬🇧 **English** | 🇧🇷 [Português](./README_pt-br.md)
+
 Ultrasonic
 ===========
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/releases/latest)
 ![Arduino Lint](https://github.com/ErickSimoes/Ultrasonic/workflows/Arduino%20Lint/badge.svg)
 
-🇬🇧 **English** | 🇧🇷 [Português](./README_pt-br.md)
+🇬🇧 **English** | 🇧🇷 [Português Brasileiro](./README_pt-br.md)
 
 Ultrasonic
 ===========

--- a/README_pt-br.md
+++ b/README_pt-br.md
@@ -3,7 +3,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/releases/latest)
 ![Arduino Lint](https://github.com/ErickSimoes/Ultrasonic/workflows/Arduino%20Lint/badge.svg)
 
-🇬🇧 [English](./README) | 🇧🇷 **Português**
+🇬🇧 [English](./README) | 🇧🇷 **Português Brasileiro**
 
 Ultrasonic
 ===========

--- a/README_pt-br.md
+++ b/README_pt-br.md
@@ -3,6 +3,8 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/releases/latest)
 ![Arduino Lint](https://github.com/ErickSimoes/Ultrasonic/workflows/Arduino%20Lint/badge.svg)
 
+🇬🇧 [English](./README) | 🇧🇷 **Português**
+
 Ultrasonic
 ===========
 

--- a/README_pt-br.md
+++ b/README_pt-br.md
@@ -3,7 +3,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/releases/latest)
 ![Arduino Lint](https://github.com/ErickSimoes/Ultrasonic/workflows/Arduino%20Lint/badge.svg)
 
-🇬🇧 [English](./README) | 🇧🇷 **Português Brasileiro**
+🇬🇧 [English](./README.md) | 🇧🇷 **Português Brasileiro**
 
 Ultrasonic
 ===========


### PR DESCRIPTION
### Summary

This Pull Request creates a link on Readme documents to different Readme languages (in this case there's a link to Portuguese Readme and vice-versa).

### Description of the Change

It creates a new line on every Readme documment to other languages that this repo support, there's also a flag representing the languages.

### Applicable Issues

Fixes #59 
Fixes #60 