### PR TITLE
[CI] Workflow to Check Arduino Examples

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -63,7 +63,7 @@ jobs:
         uses: montudor/action-zip@v0.1.1
 
       - name: Zip Ultrasonic.zip
-        run: zip -qq -r ultrasonic.zip ./
+        run: zip -qq -r ultrasonic.zip ./src/
         working-directory: ${{ github.workspace }}
 
       - name: Install Arduino CLI

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -85,4 +85,13 @@ jobs:
 
       - name: Install Ultrasonic.h
         run: arduino-cli lib install --zip-path ./ultrasonic.zip
+
+      - name: Compile Sketch UltrasonicSimple.ino
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/UltrasonicSimple
+
+      - name: Compile Sketch Timeout.ino
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Timeout
+
+      - name: Compile Sketch MultipleUltrasonicSensors.ino
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/MultipleUltrasonicSensors
     

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -59,8 +59,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Zip Ultrasonic.zip
+      - name: Install Zip
         uses: montudor/action-zip@v0.1.1
+
+      - name: Zip Ultrasonic.zip
         run: zip -qq -r ultrasonic.zip ./
         working-directory: ${{ github.workspace }}
 

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -29,3 +29,58 @@ jobs:
           #verbose: true
           #official: false
           #token: ${{ github.token }}
+
+  compile:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        boards: [arduino-uno, arduino-mega, arduino-leonardo]
+
+        include:
+          - boards: arduino-uno
+            arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:uno"
+            serial-enabled: true
+
+          - boards: arduino-mega
+            arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:mega"
+            serial-enabled: true
+
+          - boards: arduino-leonardo
+            arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:leonardo"
+            serial-enabled: true
+    
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Zip Ultrasonic.zip
+        uses: montudor/action-zip@v0.1.1
+        run: zip -qq -r ultrasonic.zip ./
+        working-directory: ${{ github.workspace }}
+
+      - name: Install Arduino CLI
+        uses: arduino/setup-arduino-cli@v1.1.1
+        with:
+          version: "0.19.x"
+
+      - name: Install Arduino Platform
+        run: |
+          arduino-cli core download ${{ matrix.arduino-platform }}
+          arduino-cli core update-index
+          arduino-cli core install ${{ matrix.arduino-platform }}
+      
+      #This is needed because we are using --zip-path to install a library
+      - name: Enables unsafe install 
+        run: |
+          arduino-cli config init 
+          arduino-cli config set library.enable_unsafe_install true
+
+      - name: Install Ultrasonic.h
+        run: arduino-cli lib install --zip-path ./ultrasonic.zip
+    

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,14 +1,15 @@
-name: Arduino Lint
+name: Check Arduino
 
 on:
   push:
     branches: [ master, test ]
-  pull_request:
+  pull_request: 
     branches: [ master, test ]
 
   workflow_dispatch:
 
 jobs:
+
   lint:
     runs-on: ubuntu-latest
     

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Open Source badge](https://img.shields.io/badge/Open%20Source-❤-red.svg)](https://opensource.org/)
 [![GitHub](https://img.shields.io/github/license/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/blob/master/LICENSE)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ErickSimoes/Ultrasonic)](https://github.com/ErickSimoes/Ultrasonic/releases/latest)
-![Arduino Lint](https://github.com/ErickSimoes/Ultrasonic/workflows/Arduino%20Lint/badge.svg)
+[![Check Arduino](https://github.com/ErickSimoes/Ultrasonic/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/ErickSimoes/Ultrasonic/actions/workflows/check-arduino.yml)
 
 Ultrasonic
 ===========


### PR DESCRIPTION
### Summary

This Pull Request creates a new Compile Action to the workflow of Ultrasonic. 

### Description of the Change

This implementation aggregates linting to a new job, instead of a single workflow, therefore, it is refactored to a new workflow called `Check Arduino` which has 2 jobs called `lint` and `compile`.

For now, the `compile` job works in a matrix in the following boards: `[arduino-uno, arduino-mega, arduino-leonardo]`.

### Benefits

Workflow Actions help maintainers to keep their code as best as possible. This workflow action helps the maintainer knows how new implementations works in different Arduino Platforms and also compile testing with different examples.

### Possible Drawbacks

If there's a major refactor or change in the code, this action may not result in a faithful result, therefore, it is advised to not use this action when there's a _breaking change_.

### Verification Process

All of the works and testing was made on [the main branch of my fork](https://github.com/SteffanoP/Ultrasonic/tree/master), there's also [the workflow from my fork](https://github.com/SteffanoP/Ultrasonic/actions/workflows/check-arduino.yml).